### PR TITLE
Fix problem where hashtag-regex index is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -809,8 +809,8 @@
       "dev": true
     },
     "hashtag-regex": {
-      "version": "github:fraction/hashtag-regex#50e1e752163824af775802ac64f33bd45aa8f6a2",
-      "from": "github:fraction/hashtag-regex#add-other-symbols"
+      "version": "github:fraction/hashtag-regex#6ebd7916aebd924a41610e72c47d51b62d506446",
+      "from": "github:fraction/hashtag-regex#requireable"
     },
     "highlight.js": {
       "version": "9.15.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "emoji-regex": "^8.0.0",
-    "hashtag-regex": "github:fraction/hashtag-regex#add-other-symbols",
+    "hashtag-regex": "github:fraction/hashtag-regex#requireable",
     "highlight.js": "^9.15.8",
     "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",


### PR DESCRIPTION
@qubist 

Oops, I pushed one last commit just after you merged it. The hashtag-regex module is set up kinda funky and they `.gitignore` the `index.js` file, so I made a change so that we can *actually* get this working.